### PR TITLE
Auto cleanup should exit application when viewModel.OldVersionModule.Count == 0

### DIFF
--- a/VS2017OfflineSetupUtility/Views/CleanUtilPage.xaml.cs
+++ b/VS2017OfflineSetupUtility/Views/CleanUtilPage.xaml.cs
@@ -36,7 +36,10 @@ namespace VS2017OfflineSetupUtility.Views
             {
                 viewModel.SelectedFolderPath = App.AutoCleanupFolder;
                 viewModel.DoClassification();
-                viewModel.DeleteOldVersionCommand.Execute();
+                if (viewModel.OldVersionModule?.Count > 0)
+                    viewModel.DeleteOldVersionCommand.Execute();
+                else
+                    Application.Current.Shutdown();
             }
             else
             {


### PR DESCRIPTION
I omitted this situation, should be fixed.